### PR TITLE
v0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,30 @@ Example usage:
 
   include apc
 
+  with parameter overrides:
+
+  class{'::apc':
+    param => 'value',
+  }
+
 Configuration:
 
-  - edit params.pp to change predefinded values
-  - add new values to augeas-command in depian.pp
+  - edit params.pp to change default values
+  - add new values to augeas-command in config.pp
 
-Author: Stefan Kögel
+Author:      Stefan Kögel
+Contributor: Dave Simons [Inuits BVBA - inuits.eu]
 
 GitHub: git@github.com:stkoegel/puppet-apc.git
 
 Changelog:
+Version 0.2 - Added CentOS support
+            - Syntax update
+            - Allow external overriding of parameters
+            - Added 'stat', 'canonicalize' and 'include_once_override' values
 Version 0.1 - Initial Commit for Debian/Ubuntu and three config values
 
 ToDo:
-- add support for RedHat and other os
 - make configuration more flexible by defining a config class (see below)
 
 define config ( $value ) {

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,27 +1,31 @@
 class apc::config {
 
-    include apc::params
-    
-    package { "apc":
-        name   => $apc::params::pkg,
-        ensure => installed,
-        require => [Class['php'],Class['apache']],
-    }
+  require apc::params
 
-    #specify your additional settings inside changes
-    augeas{ "apc.ini settings":
-        context => "/files/${apc::params::conf}",
-        lens => "PHP.lns",
-        incl => "${apc::params::conf}/apc.ini",
-        changes => [
-            "set enabled 1",
-            "set shm_size ${apc::params::shmsize}",
-            "set shm_segments ${apc::params::shmsegments}",
-            "set ttl ${apc::params::ttl}"
-        ],
-        require => [ 
-            Package["apc"],
-            Class["augeas"],
-        ],
-    }  
+  package{"apc":
+    name    => $apc::params::pkg,
+    ensure  => 'installed',
+    require => Class[
+      '::php',
+      '::apache',
+    ],
+  }
+
+  #specify your additional settings inside changes
+  augeas{"apc.ini settings":
+    context => "/files/${apc::params::conf}",
+    lens    => 'PHP.lns',
+    incl    => "${apc::params::conf}/apc.ini",
+    changes => [
+      'set enabled 1',
+      "set shm_size ${apc::params::shmsize}",
+      "set shm_segments ${apc::params::shmsegments}",
+      "set ttl ${apc::params::ttl}"
+    ],
+    require => [
+      Package['apc'],
+      Class['augeas'],
+    ],
+  }
+
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,7 +3,7 @@ class apc::config {
   require ::apc
 
   package{"apc":
-    name    => $apc::pkg,
+    name    => $::apc::pkg,
     ensure  => 'installed',
     require => Class[
       '::php',
@@ -12,18 +12,18 @@ class apc::config {
   }
 
   augeas{"apc.ini settings":
-    context => "/files/${apc::conf}",
+    context => "/files/${::apc::conf}",
     lens    => 'PHP.lns',
-    incl    => "${apc::conf}/apc.ini",
+    incl    => "${::apc::conf}/apc.ini",
     changes => [
       'set enabled 1',
-      "set shm_size ${apc::shmsize}",
-      "set shm_segments ${apc::shmsegments}",
-      "set ttl ${apc::ttl}"
+      "set shm_size ${::apc::shmsize}",
+      "set shm_segments ${::apc::shmsegments}",
+      "set ttl ${::apc::ttl}"
     ],
     require => [
       Package['apc'],
-      Class['augeas'],
+      Class['::augeas'],
     ],
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,7 +7,7 @@ class apc::config {
     ensure  => 'installed',
     require => Class[
       '::php',
-      '::apache',
+      '::apache'
     ],
   }
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,4 +1,4 @@
-class apc::debian {
+class apc::config {
 
     include apc::params
     

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,9 +1,9 @@
 class apc::config {
 
-  require apc::params
+  require ::apc
 
   package{"apc":
-    name    => $apc::params::pkg,
+    name    => $apc::pkg,
     ensure  => 'installed',
     require => Class[
       '::php',
@@ -13,14 +13,14 @@ class apc::config {
 
   #specify your additional settings inside changes
   augeas{"apc.ini settings":
-    context => "/files/${apc::params::conf}",
+    context => "/files/${apc::conf}",
     lens    => 'PHP.lns',
-    incl    => "${apc::params::conf}/apc.ini",
+    incl    => "${apc::conf}/apc.ini",
     changes => [
       'set enabled 1',
-      "set shm_size ${apc::params::shmsize}",
-      "set shm_segments ${apc::params::shmsegments}",
-      "set ttl ${apc::params::ttl}"
+      "set shm_size ${apc::shmsize}",
+      "set shm_segments ${apc::shmsegments}",
+      "set ttl ${apc::ttl}"
     ],
     require => [
       Package['apc'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -19,7 +19,10 @@ class apc::config {
       'set enabled 1',
       "set shm_size ${::apc::shmsize}",
       "set shm_segments ${::apc::shmsegments}",
-      "set ttl ${::apc::ttl}"
+      "set ttl ${::apc::ttl}",
+      "set stat ${::apc::stat}",
+      "set canonicalize ${::apc::canonicalize}",
+      "set include_once_override ${::apc::include_once_override}"
     ],
     require => [
       Package['apc'],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -11,7 +11,6 @@ class apc::config {
     ],
   }
 
-  #specify your additional settings inside changes
   augeas{"apc.ini settings":
     context => "/files/${apc::conf}",
     lens    => 'PHP.lns',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -25,11 +25,14 @@ Configuration:
 */
 
 class apc (
-  $pkg         = $::apc::params::pkg,
-  $conf        = $::apc::params::conf,
-  $shmsize     = $::apc::params::shmsize,
-  $shmsegments = $::apc::params::shmsegments,
-  $ttl         = $::apc::params::ttl,
+  $pkg                   = $::apc::params::pkg,
+  $conf                  = $::apc::params::conf,
+  $shmsize               = $::apc::params::shmsize,
+  $shmsegments           = $::apc::params::shmsegments,
+  $ttl                   = $::apc::params::ttl,
+  $stat                  = $::apc::params::stat,
+  $canonicalize          = $::apc::params::canonicalize,
+  $include_once_override = $::apc::params::include_once_override,
 ) inherits ::apc::params {
 
   case $operatingsystem {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,7 +1,8 @@
 /*
+
 == Class: apc
 
-Installs APC Support with basis configuration.
+Installs APC Support with basic configuration.
 Depends on (tested with)
  - https://github.com/camptocamp/puppet-apache.git
  - https://github.com/camptocamp/puppet-php.git
@@ -10,10 +11,17 @@ Example usage:
 
   include apc
 
+  with parameter overrides:
+
+  class{'::apc':
+    param => 'value',
+  }
+
 Configuration:
 
-  - edit params.pp to change predefinded values
-  - add new values to augeas-command in depian.pp
+  - edit params.pp to change default values
+  - add new values to augeas-command in config.pp
+
 */
 
 class apc (

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,7 +26,6 @@ Configuration:
 
 class apc (
   $pkg         = $::apc::params::pkg,
-  $php         = $::apc::params::php,
   $conf        = $::apc::params::conf,
   $shmsize     = $::apc::params::shmsize,
   $shmsegments = $::apc::params::shmsegments,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,14 @@ Configuration:
   - add new values to augeas-command in depian.pp
 */
 
-class apc {
+class apc (
+  $pkg         = $::apc::params::pkg,
+  $php         = $::apc::params::php,
+  $conf        = $::apc::params::conf,
+  $shmsize     = $::apc::params::shmsize,
+  $shmsegments = $::apc::params::shmsegments,
+  $ttl         = $::apc::params::ttl,
+) inherits ::apc::params {
 
   case $operatingsystem {
     Debian,Ubuntu,CentOS:  { include apc::config }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@ Configuration:
 
 class apc {
     case $operatingsystem {
-        Debian,Ubuntu:  { include apc::debian}
+        Debian,Ubuntu,CentOS:  { include apc::config}
         default: { fail "Unsupported operatingsystem ${operatingsystem}" }
     } 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,8 +17,10 @@ Configuration:
 */
 
 class apc {
-    case $operatingsystem {
-        Debian,Ubuntu,CentOS:  { include apc::config}
-        default: { fail "Unsupported operatingsystem ${operatingsystem}" }
-    } 
+
+  case $operatingsystem {
+    Debian,Ubuntu,CentOS:  { include apc::config }
+    default:               { fail "Unsupported operatingsystem: ${operatingsystem}" }
+  } 
+
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class apc (
 ) inherits ::apc::params {
 
   case $operatingsystem {
-    Debian,Ubuntu,CentOS:  { include apc::config }
+    Debian,Ubuntu,CentOS:  { include ::apc::config }
     default:               { fail "Unsupported operatingsystem: ${operatingsystem}" }
   } 
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,26 +1,27 @@
 class apc::params {
 
-    $pkg = $operatingsystem ? {
-        /Debian|Ubuntu/ => 'php-apc',
-    }
-    
-    #Note: apc does not macke much sense without php installed 
-    $php = $operatingsystem ? {
-        /Debian|Ubuntu/ => 'php5-cli',
-    } 
+  $pkg = $operatingsystem ? {
+    /Debian|Ubuntu/ => 'php-apc',
+  }
 
-    $conf = $operatingsystem ? {
-        /Debian|Ubuntu/ => '/etc/php5/apache2/conf.d/apc.ini/.anon/',
-    }
+  #Note: apc does not macke much sense without php installed 
+  $php = $operatingsystem ? {
+    /Debian|Ubuntu/ => 'php5-cli',
+  } 
 
-    #specify the shared memory size
-    #K - KB, M - MB, G - GB
-    $shmsize = 128M
+  $conf = $operatingsystem ? {
+    /Debian|Ubuntu/ => '/etc/php5/apache2/conf.d/apc.ini/.anon/',
+  }
 
-    #specify the number of shared memory segments
-    $shmsegments = 1
+  #specify the shared memory size
+  #K - KB, M - MB, G - GB
+  $shmsize = 128M
 
-    #specifiy the number of seconds until a cache entry will be expunged
-    #the value 0 defines that entries are not expunged until the cache is full and the space is needed
-    $ttl = 3600
+  #specify the number of shared memory segments
+  $shmsegments = 1
+
+  #specifiy the number of seconds until a cache entry will be expunged
+  #the value 0 defines that entries are not expunged until the cache is full and the space is needed
+  $ttl = 3600
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class apc::params {
     CentOS          => 'php-pecl-apc',
   }
 
-  #Note: apc does not macke much sense without php installed 
+  #Note: apc does not make much sense without php installed
   $php = $operatingsystem ? {
     /Debian|Ubuntu/ => 'php5-cli',
     CentOS          => 'php',
@@ -23,7 +23,7 @@ class apc::params {
   #specify the number of shared memory segments
   $shmsegments = 1
 
-  #specifiy the number of seconds until a cache entry will be expunged
+  #specify the number of seconds until a cache entry will be expunged
   #the value 0 defines that entries are not expunged until the cache is full and the space is needed
   $ttl = 3600
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,12 +5,6 @@ class apc::params {
     CentOS          => 'php-pecl-apc',
   }
 
-  #Note: apc does not make much sense without php installed
-  $php = $operatingsystem ? {
-    /Debian|Ubuntu/ => 'php5-cli',
-    CentOS          => 'php',
-  } 
-
   $conf = $operatingsystem ? {
     /Debian|Ubuntu/ => '/etc/php5/apache2/conf.d/apc.ini/.anon/',
     centOS          => '/etc/php.d/apc.ini/.anon/',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,4 +21,14 @@ class apc::params {
   #the value 0 defines that entries are not expunged until the cache is full and the space is needed
   $ttl = 3600
 
+  #When on this makes apc check the files every time they are queried to see if any modifications were made.
+  #Turning this off will give a significant performance boost, but should only be used when the files served are not changed often.
+  $stat = 1
+
+  #If on, then relative paths are canonicalized in no-stat mode. If set, then files included via stream wrappers can not be cached as realpath() does not support stream wrappers.
+  $canonicalize = 1
+
+  #Turning this on optimizes the 'include_once' and 'require_once' calls, to avoid the expensive system calls used.
+  $include_once_override = 0
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,15 +2,18 @@ class apc::params {
 
   $pkg = $operatingsystem ? {
     /Debian|Ubuntu/ => 'php-apc',
+    CentOS          => 'php-pecl-apc',
   }
 
   #Note: apc does not macke much sense without php installed 
   $php = $operatingsystem ? {
     /Debian|Ubuntu/ => 'php5-cli',
+    CentOS          => 'php',
   } 
 
   $conf = $operatingsystem ? {
     /Debian|Ubuntu/ => '/etc/php5/apache2/conf.d/apc.ini/.anon/',
+    centOS          => '/etc/php.d/apc.ini/.anon/',
   }
 
   #specify the shared memory size


### PR DESCRIPTION
- Added CentOS support
- Updated syntax
- allow overriding of parameters at runtime
- add 'stat', 'canonicalize' and 'include_once_override' params
